### PR TITLE
Allow for lazy loading of experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage with Google Experiments:
 app
 	.run((experiments, googleExperiments) => {
 		//Configure all the things
-		experiments.setDeferredVariation('my-experiment', googleExperiments.getVariation('googleExperimentId'));
+		experiments.setVariationFactory('my-experiment', () => googleExperiments.getVariation('googleExperimentId'));
 	})
 ```
 ```html


### PR DESCRIPTION
Usually experiments should only be initialized when the experiment is actually loaded on screen, but this previously wasn't possible. This PR introduces a new function to register a variation*Factory*, to allow lazy initialization of the experiments.

@Magnetme/monolith - RFR (Will merge and publish this already, comments will be fixed in a follow-up)