### PR TITLE
Replaced async functions with ng-async

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "main": "out/index.js",
   "dependencies": {
-    "babel-runtime": "^5.8.25"
+    "babel-runtime": "^5.8.25",
+    "ng-async": "^1.1.0"
   },
   "peerDependencies": {
     "angular": "^1.3.0"


### PR DESCRIPTION
The async functions had some digest cycle problems. Instead of trying to
fix this manually here it is better to use `ng-async`, which handles
that for us.

Closes #10

@Magnetme/monolith - RFR