### PR TITLE
Fix NPE in getVariation by checking if experiment is loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,10 @@ export default angular.module("mm.experiments", [ ngAsync.name ])
 			 * Returns a promise that resolves to a variation
 			 */
 			getVariation(name) {
+				if (!variations.has(name)) {
+					console.warn(`Experiment ${name} is not loaded`);
+					return $q.reject(`Experiment ${name} is not loaded`);
+				}
 				return variations.get(name)();
 			}
 		};
@@ -182,13 +186,22 @@ export default angular.module("mm.experiments", [ ngAsync.name ])
 				 * Returns a promise that resolves to the variation chosen
 				 */
 				this.getVariation = $async(function*() {
-					const experiment = yield this.experiment;
-					return yield experiments.getVariation(experiment);
+					try {
+						const experiment = yield this.experiment;
+						return yield experiments.getVariation(experiment);
+					} catch (e) {
+						return 0;
+					}
 				});
 			},
 			link : $async(function*(scope, el, attrs, ctrl) {
 				ctrl._setExperiment(attrs.mmExperiment);
-				scope.$variation = yield experiments.getVariation(attrs.mmExperiment);
+				try {
+					scope.$variation = yield experiments.getVariation(attrs.mmExperiment);
+				} catch (e) {
+					scope.$variation = 0;
+					throw e;
+				}
 			})
 		}
 	})


### PR DESCRIPTION
If a non-existing (or not-loaded) experiment is requested then we
shouldn't fail with an NPE, but instead provide some sane error. This PR
introduces checks at the necessary places to be able to deal with
non-existing experiments, and to log them.

If an experiment isn't loaded then it will default to variation `0`, log
the warning, and throw. The error can't be caught, since it
happens in a directive, but it will end up in logs &
`unhandledPromiseRejection` callbacks.

@Magnetme/monolith - RFR