### PR TITLE
Work around ghostery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,12 @@ export default angular.module("mm.experiments", [ ngAsync.name ])
 								} else {
 									variation = ${defaultVariation};
 								}
+								// Some ad-blockers don't nuke the cxApi, but instead replace it with a
+								// mock implementation. We also need to deal with that.
+								// E.g. ghostery has this behaviour.
+								if (typeof variation === 'undefined') {
+									variation = ${defaultVariation};
+								}
 								window.parent.mmGoogleExperimentCallback("${id}", variation);
 							</script>
 						</body>


### PR DESCRIPTION
Ghostery mocks the Google API, which confused mm-experiments. Originally reported in our monorepo https://github.com/Magnetme/magnet.me/issues/11275. 

@Magnetme/monolith - RFR